### PR TITLE
Refactor UpdateContentTxParams & UpdateContentTxResult Struct Definition

### DIFF
--- a/db/sqlc/dtos.go
+++ b/db/sqlc/dtos.go
@@ -37,26 +37,19 @@ type CreateContentTxResult struct {
 }
 
 type UpdateContentTxParams struct {
-	UserId     int64               `json:"user_id"`
-	Username   string              `json:"username"`
-	PageId     *int64              `json:"page_id"`
-	PostId     *int64              `json:"post_id"`
-	MetaPageID *int64              `json:"meta_page_id"`
-	MetaPostID *int64              `json:"meta_post_id"`
-	Pages      []UpdatePagesParams `json:"pages"`
-	Posts      []UpdatePostsParams `json:"posts"`
-	Metas      []UpdateMetaParams  `json:"meta"`
+	UserId   int64             `json:"user_id"`
+	Username string            `json:"username"`
+	PageId   *int64            `json:"page_id"`
+	PostId   *int64            `json:"post_id"`
+	Pages    UpdatePagesParams `json:"pages"`
+	Posts    UpdatePostsParams `json:"posts"`
+	Metas    UpdateMetaParams  `json:"meta"`
 }
 
 type UpdateContentTxResult struct {
-	User       User   `json:"user"`
-	PageId     *Page  `json:"pages_id"`
-	PostId     *Post  `json:"post_id"`
-	MetaPageID *Meta  `json:"meta_page_id"`
-	MetaPostID *Meta  `json:"meta_post_id"`
-	Pages      []Page `json:"page"`
-	Posts      []Post `json:"post"`
-	Metas      []Meta `json:"meta"`
+	Pages Page `json:"page"`
+	Posts Post `json:"post"`
+	Metas Meta `json:"meta"`
 }
 
 type DeleteContentTxParams struct {


### PR DESCRIPTION
# Description:

Following the revised approach where `UpdatePageTx` updates a single page along with its associated meta entry, the definition for the params and results struct (`UpdateContentTxParams`) and (`UpdateContentTxResult`) needs revision.

**Fields to be Defined:**

`UpdateContentTxParams`

- `UserId`
- `Username`
- `PageId `
- `PostId`
- `Page`
- `Posts`
- `Meta`

`UpdateContentTxResult`

- `Page`
- `Posts`
- `Meta`

**Action Items:**
- [x] Update the definition of `UpdateContentTxParams` struct to include the necessary fields.
- [x] Update the definition of `UpdateContentTxResult` struct to include the necessary fields.
- [x] Remove the following fields from `UpdateContentTxResult`:
  - `PageId`
  - `PostId`
  - `MetaPostID`
  - `MetaPageID`
  - `User`
  - `[]Pages`
  - `[]Posts`
  - `[]Metas`
- [x] Remove the following fields from `UpdateContentTxParams`:
- `MetaPageID`
- `MetaPostID`
- `[]Pages`
- `[]Posts`
- `[]Metas`

**Acceptance Criteria:**
- [x] `UpdateContentTxParams` struct includes the required fields.
- [x] `UpdateContentTxResult` struct includes the required fields.
- [x] Removed fields are successfully removed from the struct definition.