### PR TITLE
Refactor UpdatePageTx & UpdatePostsTx to Update Single Page and Meta Entry

### DIFF
--- a/db/sqlc/dtos.go
+++ b/db/sqlc/dtos.go
@@ -37,26 +37,19 @@ type CreateContentTxResult struct {
 }
 
 type UpdateContentTxParams struct {
-	UserId     int64               `json:"user_id"`
-	Username   string              `json:"username"`
-	PageId     *int64              `json:"page_id"`
-	PostId     *int64              `json:"post_id"`
-	MetaPageID *int64              `json:"meta_page_id"`
-	MetaPostID *int64              `json:"meta_post_id"`
-	Pages      []UpdatePagesParams `json:"pages"`
-	Posts      []UpdatePostsParams `json:"posts"`
-	Metas      []UpdateMetaParams  `json:"meta"`
+	UserId   int64              `json:"user_id"`
+	Username string             `json:"username"`
+	PageId   *int64             `json:"page_id"`
+	PostId   *int64             `json:"post_id"`
+	Pages    *UpdatePagesParams `json:"pages"`
+	Posts    *UpdatePostsParams `json:"posts"`
+	Metas    UpdateMetaParams   `json:"meta"`
 }
 
 type UpdateContentTxResult struct {
-	User       User   `json:"user"`
-	PageId     *Page  `json:"pages_id"`
-	PostId     *Post  `json:"post_id"`
-	MetaPageID *Meta  `json:"meta_page_id"`
-	MetaPostID *Meta  `json:"meta_post_id"`
-	Pages      []Page `json:"page"`
-	Posts      []Post `json:"post"`
-	Metas      []Meta `json:"meta"`
+	Pages Page `json:"page"`
+	Posts Post `json:"post"`
+	Metas Meta `json:"meta"`
 }
 
 type DeleteContentTxParams struct {

--- a/db/sqlc/store.go
+++ b/db/sqlc/store.go
@@ -208,7 +208,7 @@ func (store *Store) UpdatePostsTx(ctx context.Context, args UpdateContentTxParam
 
 		metaArgs := UpdateMetaParams{
 			ID:              meta.ID,
-			PostsID:         sql.NullInt64{Int64: post.ID},
+			PostsID:         sql.NullInt64{Int64: post.ID, Valid: true},
 			MetaTitle:       args.Metas.MetaTitle,
 			MetaDescription: args.Metas.MetaDescription,
 			MetaRobots:      args.Metas.MetaRobots,
@@ -277,7 +277,7 @@ func (store *Store) UpdatePageTx(ctx context.Context, args UpdateContentTxParams
 
 		metaArgs := UpdateMetaParams{
 			ID:              meta.ID,
-			PageID:          sql.NullInt64{Int64: page.ID},
+			PageID:          sql.NullInt64{Int64: page.ID, Valid: true},
 			MetaTitle:       args.Metas.MetaTitle,
 			MetaDescription: args.Metas.MetaDescription,
 			MetaRobots:      args.Metas.MetaRobots,

--- a/db/sqlc/store.go
+++ b/db/sqlc/store.go
@@ -179,35 +179,57 @@ func (store *Store) UpdatePostsTx(ctx context.Context, args UpdateContentTxParam
 		if err != nil {
 			return fmt.Errorf("get user err: %v", err)
 		}
-		result.User = user
 
 		post, err := q.GetPosts(ctx, *args.PostId)
 		if err != nil {
 			return fmt.Errorf("get post err: %v", err)
 		}
-		result.PostId = &post
 
-		meta, err := q.GetMetaByPostsIDForUpdate(ctx, sql.NullInt64{Int64: *args.MetaPostID, Valid: true})
+		meta, err := q.GetMetaByPostsIDForUpdate(ctx, sql.NullInt64{Int64: *args.PostId, Valid: true})
 		if err != nil {
 			return fmt.Errorf("get meta err: %v", err)
 		}
-		result.MetaPostID = &meta
 
-		for _, postParams := range args.Posts {
-			post, err := q.UpdatePosts(ctx, postParams)
-			if err != nil {
-				return fmt.Errorf("update post err: %v", err)
-			}
-			result.Posts = append(result.Posts, post)
+		postArgs := UpdatePostsParams{
+			ID:           post.ID,
+			Title:        args.Posts.Title,
+			Content:      args.Posts.Content,
+			AuthorID:     user.ID,
+			Url:          args.Posts.Url,
+			UpdatedAt:    args.Posts.UpdatedAt,
+			Status:       args.Posts.Status,
+			PublishedAt:  args.Posts.PublishedAt,
+			EditedAt:     args.Posts.EditedAt,
+			PostAuthor:   user.Username,
+			PostMimeType: args.Posts.PostMimeType,
+			PublishedBy:  args.Posts.PublishedBy,
+			UpdatedBy:    args.Posts.UpdatedBy,
 		}
 
-		for _, metaParas := range args.Metas {
-			meta, err := q.UpdateMeta(ctx, metaParas)
-			if err != nil {
-				return fmt.Errorf("update meta err: %v", err)
-			}
-			result.Metas = append(result.Metas, meta)
+		metaArgs := UpdateMetaParams{
+			ID:              meta.ID,
+			PostsID:         sql.NullInt64{Int64: post.ID},
+			MetaTitle:       args.Metas.MetaTitle,
+			MetaDescription: args.Metas.MetaDescription,
+			MetaRobots:      args.Metas.MetaRobots,
+			MetaOgImage:     args.Metas.MetaOgImage,
+			Locale:          args.Metas.Locale,
+			PageAmount:      args.Metas.PageAmount,
+			SiteLanguage:    args.Metas.SiteLanguage,
+			MetaKey:         args.Metas.MetaKey,
+			MetaValue:       args.Metas.MetaValue,
 		}
+
+		result.Posts, err = q.UpdatePosts(ctx, postArgs)
+		if err != nil {
+			return fmt.Errorf("update post err: %v", err)
+		}
+
+		result.Metas, err = q.UpdateMeta(ctx, metaArgs)
+		if err != nil {
+			return fmt.Errorf("update meta err: %v", err)
+		}
+
 		return nil
 	})
 	return result, err
@@ -225,35 +247,58 @@ func (store *Store) UpdatePageTx(ctx context.Context, args UpdateContentTxParams
 		if err != nil {
 			return fmt.Errorf("get user err: %v", err)
 		}
-		result.User = user
 
 		page, err := q.GetPages(ctx, *args.PageId)
 		if err != nil {
 			return fmt.Errorf("get pages err: %v", err)
 		}
-		result.PageId = &page
 
-		meta, err := q.GetMetaByPageIDForUpdate(ctx, sql.NullInt64{Int64: *args.MetaPageID, Valid: true})
+		meta, err := q.GetMetaByPageIDForUpdate(ctx, sql.NullInt64{Int64: *args.PageId, Valid: true})
 		if err != nil {
 			return fmt.Errorf("get meta err: %v", err)
 		}
-		result.MetaPageID = &meta
 
-		for _, pageParams := range args.Pages {
-			page, err := q.UpdatePages(ctx, pageParams)
-			if err != nil {
-				return fmt.Errorf("update pages err: %v", err)
-			}
-			result.Pages = append(result.Pages, page)
+		pageArgs := UpdatePagesParams{
+			ID:             page.ID,
+			Domain:         args.Pages.Domain,
+			AuthorID:       user.ID,
+			PageAuthor:     user.Username,
+			Title:          args.Pages.Title,
+			Url:            args.Pages.Url,
+			MenuOrder:      args.Pages.MenuOrder,
+			ComponentType:  args.Pages.ComponentType,
+			ComponentValue: args.Pages.ComponentValue,
+			PageIdentifier: args.Pages.PageIdentifier,
+			OptionID:       args.Pages.OptionID,
+			OptionName:     args.Pages.OptionName,
+			OptionValue:    args.Pages.OptionValue,
+			OptionRequired: args.Pages.OptionRequired,
 		}
 
-		for _, metaParas := range args.Metas {
-			meta, err := q.UpdateMeta(ctx, metaParas)
-			if err != nil {
-				return fmt.Errorf("update meta err: %v", err)
-			}
-			result.Metas = append(result.Metas, meta)
+		metaArgs := UpdateMetaParams{
+			ID:              meta.ID,
+			PageID:          sql.NullInt64{Int64: page.ID},
+			MetaTitle:       args.Metas.MetaTitle,
+			MetaDescription: args.Metas.MetaDescription,
+			MetaRobots:      args.Metas.MetaRobots,
+			MetaOgImage:     args.Metas.MetaOgImage,
+			Locale:          args.Metas.Locale,
+			PageAmount:      args.Metas.PageAmount,
+			SiteLanguage:    args.Metas.SiteLanguage,
+			MetaKey:         args.Metas.MetaKey,
+			MetaValue:       args.Metas.MetaValue,
 		}
+
+		result.Pages, err = q.UpdatePages(ctx, pageArgs)
+		if err != nil {
+			return fmt.Errorf("update pages err: %v", err)
+		}
+
+		result.Metas, err = q.UpdateMeta(ctx, metaArgs)
+		if err != nil {
+			return fmt.Errorf("update meta err: %v", err)
+		}
+
 		return nil
 	})
 	return result, err

--- a/db/sqlc/store_test.go
+++ b/db/sqlc/store_test.go
@@ -550,47 +550,41 @@ func TestUpdatePostsTx(t *testing.T) {
 			require.NoError(t, err)
 
 			result, err := store.UpdatePostsTx(context.Background(), UpdateContentTxParams{
-				UserId:     newUser.ID,
-				Username:   newUser.Username,
-				PageId:     nil,
-				PostId:     &postMeta.PostsID.Int64,
-				MetaPageID: nil,
-				MetaPostID: &postMeta.PostsID.Int64,
-				Pages:      nil,
-				Posts: []UpdatePostsParams{
-					{
-						ID:           postMeta.PostsID.Int64,
-						Title:        "Lorem ipsum dolor sit amet",
-						Content:      "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-						AuthorID:     newUser.ID,
-						Url:          "https://example.com",
-						UpdatedAt:    now,
-						Status:       "admin",
-						PublishedAt:  now,
-						EditedAt:     now,
-						PostAuthor:   newUser.Username,
-						PostMimeType: "text/plain",
-						PublishedBy:  newUser.Username,
-						UpdatedBy:    newUser.Username,
-					},
+				UserId:   newUser.ID,
+				Username: newUser.Username,
+				PageId:   nil,
+				PostId:   &postMeta.PostsID.Int64,
+				Pages:    nil,
+				Posts: &UpdatePostsParams{
+					ID:           postMeta.PostsID.Int64,
+					Title:        "Lorem ipsum dolor sit amet",
+					Content:      "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+					AuthorID:     newUser.ID,
+					Url:          "https://example.com",
+					UpdatedAt:    now,
+					Status:       "admin",
+					PublishedAt:  now,
+					EditedAt:     now,
+					PostAuthor:   newUser.Username,
+					PostMimeType: "text/plain",
+					PublishedBy:  newUser.Username,
+					UpdatedBy:    newUser.Username,
 				},
-				Metas: []UpdateMetaParams{
-					{
-						ID:              postMeta.ID,
-						PageID:          sql.NullInt64{Int64: 0, Valid: false},
-						PostsID:         sql.NullInt64{Int64: postMeta.PostsID.Int64, Valid: true},
-						MetaTitle:       sql.NullString{String: "Sample Meta Title", Valid: true},
-						MetaDescription: sql.NullString{String: "Sample Meta Description", Valid: true},
-						MetaRobots:      sql.NullString{String: "index, follow", Valid: true},
-						MetaOgImage:     sql.NullString{String: "https://example.com/image.jpg", Valid: true},
-						Locale:          sql.NullString{String: "ja_JP", Valid: true},
-						PageAmount:      3,
-						SiteLanguage: sql.NullString{
-							String: "ja", Valid: true,
-						},
-						MetaKey:   "_thumbnail_id",
-						MetaValue: "12345",
+				Metas: UpdateMetaParams{
+					ID:              postMeta.ID,
+					PageID:          sql.NullInt64{Int64: 0, Valid: false},
+					PostsID:         sql.NullInt64{Int64: postMeta.PostsID.Int64, Valid: true},
+					MetaTitle:       sql.NullString{String: "Sample Meta Title", Valid: true},
+					MetaDescription: sql.NullString{String: "Sample Meta Description", Valid: true},
+					MetaRobots:      sql.NullString{String: "index, follow", Valid: true},
+					MetaOgImage:     sql.NullString{String: "https://example.com/image.jpg", Valid: true},
+					Locale:          sql.NullString{String: "ja_JP", Valid: true},
+					PageAmount:      3,
+					SiteLanguage: sql.NullString{
+						String: "ja", Valid: true,
 					},
+					MetaKey:   "_thumbnail_id",
+					MetaValue: "12345",
 				},
 			})
 
@@ -607,54 +601,42 @@ func TestUpdatePostsTx(t *testing.T) {
 		result := <-results
 		require.NotEmpty(t, result)
 
-		user := result.User
-		require.NotEmpty(t, user)
-		require.Equal(t, newUser.ID, user.ID)
-		require.Equal(t, newUser.Username, user.Username)
-
-		_, err = store.GetUsers(context.Background(), user.ID)
-		require.NoError(t, err)
-
 		posts := result.Posts
 		require.NotEmpty(t, posts)
 
-		for _, post := range posts {
-			storePosts, err := store.GetPosts(context.Background(), post.ID)
-			require.NoError(t, err)
-			require.NotEmpty(t, storePosts)
-			require.Equal(t, post.ID, storePosts.ID)
-			require.Equal(t, post.Title, storePosts.Title)
-			require.Equal(t, post.Content, storePosts.Content)
-			require.Equal(t, post.AuthorID, storePosts.AuthorID)
-			require.Equal(t, post.Url, storePosts.Url)
-			require.Equal(t, post.Status, storePosts.Status)
-			require.Equal(t, post.PublishedAt, storePosts.PublishedAt)
-			require.Equal(t, post.EditedAt, storePosts.EditedAt)
-			require.Equal(t, post.PostAuthor, storePosts.PostAuthor)
-			require.Equal(t, post.PostMimeType, storePosts.PostMimeType)
-			require.Equal(t, post.PublishedBy, storePosts.PublishedBy)
-			require.Equal(t, post.UpdatedAt, storePosts.UpdatedAt)
-		}
+		storePosts, err := store.GetPosts(context.Background(), posts.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, storePosts)
+		require.Equal(t, posts.ID, storePosts.ID)
+		require.Equal(t, posts.Title, storePosts.Title)
+		require.Equal(t, posts.Content, storePosts.Content)
+		require.Equal(t, posts.AuthorID, storePosts.AuthorID)
+		require.Equal(t, posts.Url, storePosts.Url)
+		require.Equal(t, posts.Status, storePosts.Status)
+		require.Equal(t, posts.PublishedAt, storePosts.PublishedAt)
+		require.Equal(t, posts.EditedAt, storePosts.EditedAt)
+		require.Equal(t, posts.PostAuthor, storePosts.PostAuthor)
+		require.Equal(t, posts.PostMimeType, storePosts.PostMimeType)
+		require.Equal(t, posts.PublishedBy, storePosts.PublishedBy)
+		require.Equal(t, posts.UpdatedAt, storePosts.UpdatedAt)
 
 		metas := result.Metas
 		require.NotEmpty(t, metas)
 
-		for _, meta := range metas {
-			storeMeta, err := store.GetMeta(context.Background(), meta.ID)
-			require.NoError(t, err)
-			require.NotEmpty(t, storeMeta)
-			require.Equal(t, meta.ID, storeMeta.ID)
-			require.Equal(t, meta.PostsID, storeMeta.PostsID)
-			require.Equal(t, meta.MetaTitle, storeMeta.MetaTitle)
-			require.Equal(t, meta.MetaDescription, storeMeta.MetaDescription)
-			require.Equal(t, meta.MetaRobots, storeMeta.MetaRobots)
-			require.Equal(t, meta.MetaOgImage, storeMeta.MetaOgImage)
-			require.Equal(t, meta.Locale, storeMeta.Locale)
-			require.Equal(t, meta.PageAmount, storeMeta.PageAmount)
-			require.Equal(t, meta.SiteLanguage, storeMeta.SiteLanguage)
-			require.Equal(t, meta.MetaKey, storeMeta.MetaKey)
-			require.Equal(t, meta.MetaValue, storeMeta.MetaValue)
-		}
+		storeMeta, err := store.GetMeta(context.Background(), metas.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, storeMeta)
+		require.Equal(t, metas.ID, storeMeta.ID)
+		require.Equal(t, metas.PostsID, storeMeta.PostsID)
+		require.Equal(t, metas.MetaTitle, storeMeta.MetaTitle)
+		require.Equal(t, metas.MetaDescription, storeMeta.MetaDescription)
+		require.Equal(t, metas.MetaRobots, storeMeta.MetaRobots)
+		require.Equal(t, metas.MetaOgImage, storeMeta.MetaOgImage)
+		require.Equal(t, metas.Locale, storeMeta.Locale)
+		require.Equal(t, metas.PageAmount, storeMeta.PageAmount)
+		require.Equal(t, metas.SiteLanguage, storeMeta.SiteLanguage)
+		require.Equal(t, metas.MetaKey, storeMeta.MetaKey)
+		require.Equal(t, metas.MetaValue, storeMeta.MetaValue)
 	}
 }
 
@@ -681,48 +663,42 @@ func TestUpdatePageTx(t *testing.T) {
 			require.NoError(t, err)
 
 			result, err := store.UpdatePageTx(context.Background(), UpdateContentTxParams{
-				UserId:     newUser.ID,
-				Username:   newUser.Username,
-				PageId:     &postMeta.PageID.Int64,
-				PostId:     nil,
-				MetaPageID: &postMeta.PageID.Int64,
-				MetaPostID: nil,
-				Pages: []UpdatePagesParams{
-					{
-						ID:             postMeta.PageID.Int64,
-						Domain:         "example.com",
-						AuthorID:       newUser.ID,
-						PageAuthor:     newUser.Username,
-						Title:          "Homepage",
-						Url:            "/home",
-						MenuOrder:      1,
-						ComponentType:  "Text",
-						ComponentValue: "Welcome to our website!",
-						PageIdentifier: "home",
-						OptionID:       98765,
-						OptionName:     "site_title",
-						OptionValue:    "My Website",
-						OptionRequired: true,
-					},
+				UserId:   newUser.ID,
+				Username: newUser.Username,
+				PageId:   &postMeta.PageID.Int64,
+				PostId:   nil,
+				Pages: &UpdatePagesParams{
+					ID:             postMeta.PageID.Int64,
+					Domain:         "example.com",
+					AuthorID:       newUser.ID,
+					PageAuthor:     newUser.Username,
+					Title:          "Homepage",
+					Url:            "/home",
+					MenuOrder:      1,
+					ComponentType:  "Text",
+					ComponentValue: "Welcome to our website!",
+					PageIdentifier: "home",
+					OptionID:       98765,
+					OptionName:     "site_title",
+					OptionValue:    "My Website",
+					OptionRequired: true,
 				},
 				Posts: nil,
-				Metas: []UpdateMetaParams{
-					{
-						ID:              postMeta.ID,
-						PageID:          sql.NullInt64{Int64: postMeta.PageID.Int64, Valid: true},
-						PostsID:         sql.NullInt64{Int64: 0, Valid: false},
-						MetaTitle:       sql.NullString{String: "Sample Meta Title", Valid: true},
-						MetaDescription: sql.NullString{String: "Sample Meta Description", Valid: true},
-						MetaRobots:      sql.NullString{String: "index, follow", Valid: true},
-						MetaOgImage:     sql.NullString{String: "https://example.com/image.jpg", Valid: true},
-						Locale:          sql.NullString{String: "ja_JP", Valid: true},
-						PageAmount:      3,
-						SiteLanguage: sql.NullString{
-							String: "ja", Valid: true,
-						},
-						MetaKey:   "_thumbnail_id",
-						MetaValue: "12345",
+				Metas: UpdateMetaParams{
+					ID:              postMeta.ID,
+					PageID:          sql.NullInt64{Int64: postMeta.PageID.Int64, Valid: true},
+					PostsID:         sql.NullInt64{Int64: 0, Valid: false},
+					MetaTitle:       sql.NullString{String: "Sample Meta Title", Valid: true},
+					MetaDescription: sql.NullString{String: "Sample Meta Description", Valid: true},
+					MetaRobots:      sql.NullString{String: "index, follow", Valid: true},
+					MetaOgImage:     sql.NullString{String: "https://example.com/image.jpg", Valid: true},
+					Locale:          sql.NullString{String: "ja_JP", Valid: true},
+					PageAmount:      3,
+					SiteLanguage: sql.NullString{
+						String: "ja", Valid: true,
 					},
+					MetaKey:   "_thumbnail_id",
+					MetaValue: "12345",
 				},
 			})
 
@@ -739,56 +715,47 @@ func TestUpdatePageTx(t *testing.T) {
 		result := <-results
 		require.NotEmpty(t, result)
 
-		user := result.User
-		require.NotEmpty(t, user)
-		require.Equal(t, newUser.ID, user.ID)
-		require.Equal(t, newUser.Username, user.Username)
-
-		_, err = store.GetUsers(context.Background(), user.ID)
+		_, err = store.GetUsers(context.Background(), newUser.ID)
 		require.NoError(t, err)
 
 		pages := result.Pages
 		require.NotEmpty(t, pages)
 
-		for _, page := range pages {
-			storePage, err := store.GetPages(context.Background(), page.ID)
-			require.NoError(t, err)
-			require.NotEmpty(t, storePage)
-			require.Equal(t, storePage.ID, page.ID)
-			require.Equal(t, storePage.Domain, page.Domain)
-			require.Equal(t, storePage.AuthorID, page.AuthorID)
-			require.Equal(t, storePage.PageAuthor, page.PageAuthor)
-			require.Equal(t, storePage.Title, page.Title)
-			require.Equal(t, storePage.Url, page.Url)
-			require.Equal(t, storePage.MenuOrder, page.MenuOrder)
-			require.Equal(t, storePage.ComponentType, page.ComponentType)
-			require.Equal(t, storePage.ComponentValue, page.ComponentValue)
-			require.Equal(t, storePage.PageIdentifier, page.PageIdentifier)
-			require.Equal(t, storePage.OptionID, page.OptionID)
-			require.Equal(t, storePage.OptionName, page.OptionName)
-			require.Equal(t, storePage.OptionValue, page.OptionValue)
-			require.Equal(t, storePage.OptionRequired, page.OptionRequired)
-		}
+		storePage, err := store.GetPages(context.Background(), pages.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, storePage)
+		require.Equal(t, storePage.ID, pages.ID)
+		require.Equal(t, storePage.Domain, pages.Domain)
+		require.Equal(t, storePage.AuthorID, pages.AuthorID)
+		require.Equal(t, storePage.PageAuthor, pages.PageAuthor)
+		require.Equal(t, storePage.Title, pages.Title)
+		require.Equal(t, storePage.Url, pages.Url)
+		require.Equal(t, storePage.MenuOrder, pages.MenuOrder)
+		require.Equal(t, storePage.ComponentType, pages.ComponentType)
+		require.Equal(t, storePage.ComponentValue, pages.ComponentValue)
+		require.Equal(t, storePage.PageIdentifier, pages.PageIdentifier)
+		require.Equal(t, storePage.OptionID, pages.OptionID)
+		require.Equal(t, storePage.OptionName, pages.OptionName)
+		require.Equal(t, storePage.OptionValue, pages.OptionValue)
+		require.Equal(t, storePage.OptionRequired, pages.OptionRequired)
 
 		metas := result.Metas
 		require.NotEmpty(t, metas)
 
-		for _, meta := range metas {
-			storeMeta, err := store.GetMeta(context.Background(), meta.ID)
-			require.NoError(t, err)
-			require.NotEmpty(t, storeMeta)
-			require.Equal(t, meta.ID, storeMeta.ID)
-			require.Equal(t, meta.PageID, storeMeta.PageID)
-			require.Equal(t, meta.MetaTitle, storeMeta.MetaTitle)
-			require.Equal(t, meta.MetaDescription, storeMeta.MetaDescription)
-			require.Equal(t, meta.MetaRobots, storeMeta.MetaRobots)
-			require.Equal(t, meta.MetaOgImage, storeMeta.MetaOgImage)
-			require.Equal(t, meta.Locale, storeMeta.Locale)
-			require.Equal(t, meta.PageAmount, storeMeta.PageAmount)
-			require.Equal(t, meta.SiteLanguage, storeMeta.SiteLanguage)
-			require.Equal(t, meta.MetaKey, storeMeta.MetaKey)
-			require.Equal(t, meta.MetaValue, storeMeta.MetaValue)
-		}
+		storeMeta, err := store.GetMeta(context.Background(), metas.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, storeMeta)
+		require.Equal(t, metas.ID, storeMeta.ID)
+		require.Equal(t, metas.PageID, storeMeta.PageID)
+		require.Equal(t, metas.MetaTitle, storeMeta.MetaTitle)
+		require.Equal(t, metas.MetaDescription, storeMeta.MetaDescription)
+		require.Equal(t, metas.MetaRobots, storeMeta.MetaRobots)
+		require.Equal(t, metas.MetaOgImage, storeMeta.MetaOgImage)
+		require.Equal(t, metas.Locale, storeMeta.Locale)
+		require.Equal(t, metas.PageAmount, storeMeta.PageAmount)
+		require.Equal(t, metas.SiteLanguage, storeMeta.SiteLanguage)
+		require.Equal(t, metas.MetaKey, storeMeta.MetaKey)
+		require.Equal(t, metas.MetaValue, storeMeta.MetaValue)
 	}
 }
 

--- a/db/sqlc/store_test.go
+++ b/db/sqlc/store_test.go
@@ -656,7 +656,7 @@ func TestUpdatePageTx(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func() {
 
-			postMeta, err := store.GetMetaByPageIDForUpdate(context.Background(), sql.NullInt64{
+			pageMeta, err := store.GetMetaByPageIDForUpdate(context.Background(), sql.NullInt64{
 				Int64: newMeta.PageID.Int64,
 				Valid: true,
 			})
@@ -665,10 +665,10 @@ func TestUpdatePageTx(t *testing.T) {
 			result, err := store.UpdatePageTx(context.Background(), UpdateContentTxParams{
 				UserId:   newUser.ID,
 				Username: newUser.Username,
-				PageId:   &postMeta.PageID.Int64,
+				PageId:   &pageMeta.PageID.Int64,
 				PostId:   nil,
 				Pages: &UpdatePagesParams{
-					ID:             postMeta.PageID.Int64,
+					ID:             pageMeta.PageID.Int64,
 					Domain:         "example.com",
 					AuthorID:       newUser.ID,
 					PageAuthor:     newUser.Username,
@@ -685,8 +685,8 @@ func TestUpdatePageTx(t *testing.T) {
 				},
 				Posts: nil,
 				Metas: UpdateMetaParams{
-					ID:              postMeta.ID,
-					PageID:          sql.NullInt64{Int64: postMeta.PageID.Int64, Valid: true},
+					ID:              pageMeta.ID,
+					PageID:          sql.NullInt64{Int64: pageMeta.PageID.Int64, Valid: true},
 					PostsID:         sql.NullInt64{Int64: 0, Valid: false},
 					MetaTitle:       sql.NullString{String: "Sample Meta Title", Valid: true},
 					MetaDescription: sql.NullString{String: "Sample Meta Description", Valid: true},


### PR DESCRIPTION
# Description:
The current implementation of `UpdatePageTx` and `UpdatePostsTx` allows updating multiple pages or posts and multiple meta entries within a single transaction. Refactor these functions to update only a single page or posts along with a single meta entry in a single transaction.

**Tasks:**
- [x] Modify the `UpdatePageTx` function to handle only one page update.
- [x] Modify the `UpdatePostsTx` function to handle only one post update.
- [x] Ensure that the transaction includes only one meta entry update.
- [x] Update tests to reflect the new behavior and ensure all tests pass.

**Acceptance Criteria:**
- [x] `UpdatePageTx` and `UpdatePostsTx` updates a single page and a single meta entry within one transaction.
- [x] All related tests are updated and pass successfully.
